### PR TITLE
Backwards compatibility for GriefPrevention hook

### DIFF
--- a/src/main/java/xyz/geik/farmer/integrations/grief/GriefPrevent.java
+++ b/src/main/java/xyz/geik/farmer/integrations/grief/GriefPrevent.java
@@ -35,7 +35,7 @@ public class GriefPrevent extends Integrations {
      */
     @Override
     public UUID getOwnerUUID(String regionId) {
-        return grief.dataStore.getClaim(Long.parseLong(regionId)).getOwnerID();
+        return grief.dataStore.getClaim(Long.parseLong(regionId)).ownerID;
     }
 
     /**
@@ -43,7 +43,7 @@ public class GriefPrevent extends Integrations {
      */
     @Override
     public UUID getOwnerUUID(Location location) {
-        return grief.dataStore.getClaimAt(location, true, null).getOwnerID();
+        return grief.dataStore.getClaimAt(location, true, null).ownerID;
     }
 
     /**


### PR DESCRIPTION
Older versions of GriefPrevention (such as 13.9.1, which is the latest version that supports 1.8) don't have Claim#getOwnerId() so we'll use Claim.ownerId instead. (which exists on both latest and 13.9.1 versions)