### PR TITLE
Land integration fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.github.angeschossen</groupId>
             <artifactId>LandsAPI</artifactId>
-            <version>6.37.0</version>
+            <version>7.1.12</version>
             <scope>provided</scope>
         </dependency>
         <!-- WildStacker -->

--- a/src/main/java/xyz/geik/farmer/integrations/lands/Lands.java
+++ b/src/main/java/xyz/geik/farmer/integrations/lands/Lands.java
@@ -1,7 +1,10 @@
 package xyz.geik.farmer.integrations.lands;
 
 import me.angeschossen.lands.api.LandsIntegration;
+import me.angeschossen.lands.api.applicationframework.util.ULID;
+import me.angeschossen.lands.api.land.Land;
 import org.bukkit.Location;
+import org.bukkit.World;
 import xyz.geik.farmer.Main;
 import xyz.geik.farmer.integrations.Integrations;
 
@@ -21,19 +24,21 @@ public class Lands extends Integrations {
      */
     public Lands() {
         super(new LandsListener());
+        api = LandsIntegration.of(Main.getInstance());
     }
 
     /**
      * Lands API
      */
-    LandsIntegration api = LandsIntegration.of(Main.getInstance());
+    LandsIntegration api;
 
     /**
      * Getting Owner UUID by Region ID
      */
     @Override
     public UUID getOwnerUUID(String regionID) {
-        return api.getLandByName(regionID).getOwnerUID();
+        ULID ulid = ULID.fromString(regionID);
+        return api.getLandByULID(ulid).getOwnerUID();
     }
 
     /**
@@ -49,6 +54,11 @@ public class Lands extends Integrations {
      */
     @Override
     public String getRegionID(Location location) {
-        return UUID.fromString(api.getArea(location).getLand().getName()).toString();
+        World world = location.getWorld();
+        int chunkX = location.getChunk().getX();
+        int chunkZ = location.getChunk().getZ();
+
+        Land land = api.getLandByChunk(world, chunkX, chunkZ);
+        return land == null ? null : land.getULID().toString();
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,8 +4,8 @@ main: xyz.geik.farmer.Main
 version: v6-b100
 api-version: 1.13
 depend: [PlaceholderAPI]
-softdepend: [Vault, RoyaleEconomy, PlayerPoints, GrinGotts, ElementalGems, ASkyBlock, BentoBox, SuperiorSkyblock2, GriefPrevention, FabledSkyBlock]
-loadbefore: [AutoPickup, WildStacker]
+softdepend: [Vault, RoyaleEconomy, PlayerPoints, GrinGotts, ElementalGems, ASkyBlock, BentoBox, SuperiorSkyblock2, GriefPrevention, FabledSkyBlock, Lands]
+loadbefore: [AutoPickup]
 commands:
   farmer:
     description: Main command of farmer


### PR DESCRIPTION
In the latest versions Lands is using ULIDs instead of a name as UUID. This PR fixes this issue and makes the Land integration work again.