### PR TITLE
Fix GriefPrevention not found & Add FarmerInv#sumItemAmount(XMaterial, int)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
         </dependency>
         <!-- GriefPreventionAPI -->
         <dependency>
-            <groupId>com.github.TechFortress</groupId>
+            <groupId>com.github.GriefPrevention</groupId>
             <artifactId>GriefPrevention</artifactId>
-            <version>16.18.3</version>
+            <version>16.18.2</version>
             <scope>provided</scope>
         </dependency>
         <!-- BentoBox -->

--- a/src/main/java/xyz/geik/farmer/model/inventory/FarmerInv.java
+++ b/src/main/java/xyz/geik/farmer/model/inventory/FarmerInv.java
@@ -114,15 +114,7 @@ public class FarmerInv {
         long amount = collectedItem.getItemStack().getAmount();
         if (Bukkit.getPluginManager().isPluginEnabled("WildStacker"))
             amount = WildStackerAPI.getItemAmount(collectedItem);
-        long canTake = capacity - item.getAmount();
-        if (canTake < amount) {
-            setItemAmount(material, capacity);
-            return amount - canTake;
-        }
-        else {
-            item.sumAmount(amount);
-            return 0L;
-        }
+        return sumItemAmount(material, amount);
     }
 
     /**
@@ -133,7 +125,7 @@ public class FarmerInv {
      * @param amount amount of the item
      * @return long left amount of item
      */
-    public long sumItemAmount(XMaterial material, int amount) {
+    public long sumItemAmount(XMaterial material, long amount) {
         FarmerItem item = getStockedItem(material);
         long canTake = capacity - item.getAmount();
         if (canTake < amount) {

--- a/src/main/java/xyz/geik/farmer/model/inventory/FarmerInv.java
+++ b/src/main/java/xyz/geik/farmer/model/inventory/FarmerInv.java
@@ -126,6 +126,27 @@ public class FarmerInv {
     }
 
     /**
+     * Adding item amount to stock.
+     * Respects capacity and if it above capacity
+     * return additional amount.
+     * @param material xmaterial of item
+     * @param amount amount of the item
+     * @return long left amount of item
+     */
+    public long sumItemAmount(XMaterial material, int amount) {
+        FarmerItem item = getStockedItem(material);
+        long canTake = capacity - item.getAmount();
+        if (canTake < amount) {
+            setItemAmount(material, capacity);
+            return amount - canTake;
+        }
+        else {
+            item.sumAmount(amount);
+            return 0L;
+        }
+    }
+
+    /**
      * Forces adding item amount to stock.
      * Doesn't respect capacity.
      *


### PR DESCRIPTION
- Adds `FarmerInv#sumItemAmount(XMaterial, int)` (mostly for my personal use)
- Fixes GriefPrevention not found. (they changed their org name)

Due to GriefPrevention being not existsing, jitpack was not able to build the latest version (b104).