### PR TITLE
Fixed perm check on farmer command

### DIFF
--- a/src/main/java/xyz/geik/farmer/commands/FarmerCommand.java
+++ b/src/main/java/xyz/geik/farmer/commands/FarmerCommand.java
@@ -11,6 +11,7 @@ import xyz.geik.farmer.api.managers.FarmerManager;
 import xyz.geik.farmer.guis.BuyGui;
 import xyz.geik.farmer.guis.MainGui;
 import xyz.geik.farmer.helpers.CacheLoader;
+import xyz.geik.farmer.helpers.WorldHelper;
 import xyz.geik.farmer.model.Farmer;
 import xyz.geik.farmer.model.FarmerLevel;
 import xyz.geik.farmer.modules.FarmerModule;
@@ -51,7 +52,7 @@ public class FarmerCommand extends BaseCommand {
             return;
         }
         Player player = (Player) sender;
-        if (!Main.getConfigFile().getSettings().getAllowedWorlds().contains(player.getWorld().getName())) {
+        if (!WorldHelper.isFarmerAllowed(player.getWorld().getName())) {
             ChatUtils.sendMessage(player, Main.getLangFile().getMessages().getWrongWorld());
             return;
         }
@@ -225,7 +226,7 @@ public class FarmerCommand extends BaseCommand {
             return;
         }
         // Check world is suitable for farmer
-        if (!Main.getConfigFile().getSettings().getAllowedWorlds().contains(player.getWorld().getName())) {
+        if (!WorldHelper.isFarmerAllowed(player.getWorld().getName())) {
             ChatUtils.sendMessage(player, Main.getLangFile().getMessages().getWrongWorld());
             return;
         }

--- a/src/main/java/xyz/geik/farmer/commands/FarmerCommand.java
+++ b/src/main/java/xyz/geik/farmer/commands/FarmerCommand.java
@@ -74,8 +74,9 @@ public class FarmerCommand extends BaseCommand {
                 ChatUtils.sendMessage(player, Main.getLangFile().getMessages().getMustBeOwner());
         } else {
             // Perm && user check
-            if (FarmerManager.getFarmers().get(regionID).getUsers().stream()
-                    .anyMatch(usr -> (usr.getUuid().equals(player.getUniqueId()))))
+            if (player.hasPermission("farmer.admin") ||
+                    FarmerManager.getFarmers().get(regionID).getUsers().stream()
+                            .anyMatch(usr -> (usr.getUuid().equals(player.getUniqueId()))))
                 MainGui.showGui(player, FarmerManager.getFarmers().get(regionID));
             else
                 ChatUtils.sendMessage(player, Main.getLangFile().getMessages().getNoPerm());

--- a/src/main/java/xyz/geik/farmer/configuration/ConfigFile.java
+++ b/src/main/java/xyz/geik/farmer/configuration/ConfigFile.java
@@ -57,8 +57,8 @@ public class ConfigFile extends OkaeriConfig {
         @Comment("farmer ignore collecting if item dropped by player")
         private boolean ignorePlayerDrop = false;
 
-        @Comment("Allowed worlds")
-        private List<String> allowedWorlds = Arrays.asList("ASkyBlock", "Island", "SuperiorWorld", "bskyblock_world", "island_normal_world");
+        @Comment("Allowed worlds. You can also use worlds like 'island_*' to allow all worlds that contains 'island_' prefix.")
+        private List<String> allowedWorlds = Arrays.asList("ASkyBlock", "Island", "SuperiorWorld", "bskyblock_world", "island_normal_world", "island_*");
 
         @Comment("Default role which will be assigned to joined player (Options: COOP - MEMBER)")
         private String defaultJoinRole = "COOP";

--- a/src/main/java/xyz/geik/farmer/helpers/WorldHelper.java
+++ b/src/main/java/xyz/geik/farmer/helpers/WorldHelper.java
@@ -1,0 +1,41 @@
+package xyz.geik.farmer.helpers;
+
+import xyz.geik.farmer.Main;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class WorldHelper {
+
+    /**
+     * Checks if Farmer is allowed in a specified world.
+     *
+     * @param worldName   The name of the world to check.
+     * @return            if Farmer is allowed in the specified world
+     */
+    public static boolean isFarmerAllowed(String worldName) {
+        // Retrieve the list of allowed worlds from the configuration.
+        List<String> allowedWorlds = new ArrayList<>(Main.getConfigFile().getSettings().getAllowedWorlds());
+
+        for (String world : allowedWorlds) {
+            // Check if the current world uses a wildcard.
+            if (world.contains("*")) {
+                // Remove the wildcard for partial matching.
+                world = world.replace("*", "");
+                // Check if the worldName contains the current world (after removing the wildcard).
+                if (worldName.contains(world)) return true;
+            }
+            else {
+                // Check if the worldName matches the current world exactly
+                if (world.equals(worldName)) {
+                    return true;
+                }
+            }
+        }
+
+        // Return false if no match is found.
+        return false;
+    }
+
+}

--- a/src/main/java/xyz/geik/farmer/listeners/backend/ItemEvent.java
+++ b/src/main/java/xyz/geik/farmer/listeners/backend/ItemEvent.java
@@ -11,6 +11,7 @@ import xyz.geik.farmer.Main;
 import xyz.geik.farmer.api.handlers.FarmerItemCollectEvent;
 import xyz.geik.farmer.api.handlers.FarmerStorageFullEvent;
 import xyz.geik.farmer.api.managers.FarmerManager;
+import xyz.geik.farmer.helpers.WorldHelper;
 import xyz.geik.farmer.model.Farmer;
 import xyz.geik.farmer.model.inventory.FarmerInv;
 import xyz.geik.glib.shades.xseries.XMaterial;
@@ -70,7 +71,7 @@ public class ItemEvent implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void itemSpawnEvent(@NotNull ItemSpawnEvent e) {
         // Checks world suitable for farmer
-        if (!Main.getConfigFile().getSettings().getAllowedWorlds().contains(e.getLocation().getWorld().getName()))
+        if (!WorldHelper.isFarmerAllowed(e.getLocation().getWorld().getName()))
             return;
         // Checks if player dropped or naturally dropped
         // if settings contain Cancel player drop then it cancel collecting it.

--- a/src/main/java/xyz/geik/farmer/listeners/backend/QuitEvent.java
+++ b/src/main/java/xyz/geik/farmer/listeners/backend/QuitEvent.java
@@ -8,6 +8,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.jetbrains.annotations.NotNull;
 import xyz.geik.farmer.Main;
 import xyz.geik.farmer.api.managers.FarmerManager;
+import xyz.geik.farmer.helpers.WorldHelper;
 import xyz.geik.farmer.model.Farmer;
 
 /**
@@ -31,7 +32,7 @@ public class QuitEvent implements Listener {
     public void onQuitEvent(@NotNull PlayerQuitEvent e) {
         final Location loc = e.getPlayer().getLocation();
         Bukkit.getScheduler().runTaskAsynchronously(Main.getInstance(), () -> {
-            if (Main.getConfigFile().getSettings().getAllowedWorlds().contains(loc.getWorld().getName())) {
+            if (WorldHelper.isFarmerAllowed(loc.getWorld().getName())) {
                 try {
                     String regionID = Main.getIntegration().getRegionID(loc);
                     if (regionID == null || !FarmerManager.getFarmers().containsKey(regionID))

--- a/src/main/java/xyz/geik/farmer/modules/autoharvest/handlers/AutoHarvestEvent.java
+++ b/src/main/java/xyz/geik/farmer/modules/autoharvest/handlers/AutoHarvestEvent.java
@@ -14,6 +14,7 @@ import org.bukkit.material.MaterialData;
 import org.jetbrains.annotations.NotNull;
 import xyz.geik.farmer.Main;
 import xyz.geik.farmer.api.managers.FarmerManager;
+import xyz.geik.farmer.helpers.WorldHelper;
 import xyz.geik.farmer.model.Farmer;
 import xyz.geik.farmer.model.inventory.FarmerInv;
 import xyz.geik.farmer.model.inventory.FarmerItem;
@@ -43,7 +44,7 @@ public class AutoHarvestEvent implements Listener {
         Block block = event.getNewState().getBlock();
         XMaterial material = parseMaterial(XMaterial.matchXMaterial(event.getNewState().getType()));
         // Checks world suitable for farmer
-        if (!Main.getConfigFile().getSettings().getAllowedWorlds().contains(block.getWorld().getName()))
+        if (!WorldHelper.isFarmerAllowed(block.getWorld().getName()))
             return;
 
         // Checks auto harvest, harvests this block.

--- a/src/main/java/xyz/geik/farmer/modules/voucher/handlers/VoucherEvent.java
+++ b/src/main/java/xyz/geik/farmer/modules/voucher/handlers/VoucherEvent.java
@@ -12,6 +12,7 @@ import xyz.geik.farmer.Main;
 import xyz.geik.farmer.api.handlers.FarmerRemoveEvent;
 import xyz.geik.farmer.api.managers.FarmerManager;
 import xyz.geik.farmer.guis.MainGui;
+import xyz.geik.farmer.helpers.WorldHelper;
 import xyz.geik.farmer.model.Farmer;
 import xyz.geik.farmer.model.FarmerLevel;
 import xyz.geik.farmer.modules.voucher.Voucher;
@@ -56,7 +57,7 @@ public class VoucherEvent implements Listener {
         if (!voucherBase.equals(event.getItem()))
             return;
         event.setCancelled(true);
-        if (!Main.getConfigFile().getSettings().getAllowedWorlds().contains(player.getWorld().getName())) {
+        if (!WorldHelper.isFarmerAllowed(player.getWorld().getName())) {
             player.sendMessage(Voucher.getInstance().getLang().getText("wrongWorld"));
             return;
         }


### PR DESCRIPTION
Admins who have "farmer.admin" permission can't open players' farmers. This PR fixes this issue and adds "farmer.admin" permission check on opening farmers in an area.