### PR TITLE
Fix item name handling on /fm sell by replacing spaces with underscores

### DIFF
--- a/src/main/java/xyz/geik/farmer/modules/geyser/commands/GeyserCommand.java
+++ b/src/main/java/xyz/geik/farmer/modules/geyser/commands/GeyserCommand.java
@@ -99,9 +99,9 @@ public class GeyserCommand extends BaseCommand {
                     String checkMaterial = item;
                     // If default items does not contain the material
 
-                    // Replace spaces with underscores for item names to avoid "too many arguments" error in Minecraft commands.
+                    // Directly compare item names without altering them to avoid "too many arguments" error in Minecraft commands.
                     if (FarmerInv.defaultItems.stream()
-                            .noneMatch(defaultItem -> defaultItem.getMaterial().toString().replaceAll(" ", "_").equalsIgnoreCase(checkMaterial))) {
+                            .noneMatch(defaultItem -> defaultItem.getMaterial().name().equalsIgnoreCase(checkMaterial))) {
                         player.sendMessage(Geyser.getInstance().getLang().getText("cantFindTheItem"));
                         return;
                     }

--- a/src/main/java/xyz/geik/farmer/modules/geyser/commands/GeyserCommand.java
+++ b/src/main/java/xyz/geik/farmer/modules/geyser/commands/GeyserCommand.java
@@ -98,8 +98,10 @@ public class GeyserCommand extends BaseCommand {
                         item = Geyser.getNameReplacer().get(item);
                     String checkMaterial = item;
                     // If default items does not contain the material
+
+                    // Replace spaces with underscores for item names to avoid "too many arguments" error in Minecraft commands.
                     if (FarmerInv.defaultItems.stream()
-                            .noneMatch(defaultItem -> defaultItem.getMaterial().toString().equalsIgnoreCase(checkMaterial))) {
+                            .noneMatch(defaultItem -> defaultItem.getMaterial().toString().replaceAll(" ", "_").equalsIgnoreCase(checkMaterial))) {
                         player.sendMessage(Geyser.getInstance().getLang().getText("cantFindTheItem"));
                         return;
                     }


### PR DESCRIPTION
This PR fixes the handling of item names in sell command to directly compare with enum names.. This change prevents the "too many arguments" error when entering multi-word item names in Minecraft commands.

The issue arises because the XMaterial enum names for multi-word items use underscores (e.g., "IRON_INGOT"), while the .toString() method returns them as "Iron Ingot". 

If someone thinks that this could be fixed directly with the sellReplace configuration, it's important to note that using:
```yml
- sellReplace: 
  - "iron:iron ingot"
```
will not work, as the enum won't find "iron ingot" and resulting in an error at:
```java
FarmerItem toSell = farmer.getInv().getStockedItem(XMaterial.valueOf(item.toUpperCase(Locale.ENGLISH)));
```
Instead, if you use:
```yml
- sellReplace: 
  - "iron:iron_ingot"
```
will also not work because XMaterial.toString() returns "Iron Ingot" not "IRON_INGOT", leading to the "item not found" message.

This change ensures that item name handling is consistent and functional, resolving these discrepancies.