### PR TITLE
Fix NPE and NoSuchElementException in Towny integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>towny</artifactId>
-            <version>0.100.3.0</version>
+            <version>0.100.4.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- LandsAPI -->

--- a/src/main/java/xyz/geik/farmer/api/managers/FarmerManager.java
+++ b/src/main/java/xyz/geik/farmer/api/managers/FarmerManager.java
@@ -68,7 +68,7 @@ public class FarmerManager {
             // Replaces old owner role to coop on db
             Main.getInstance().getSql().updateRole(oldOwner, 1, newFarmer.getId());
             // Replace old owner role to coop on cache
-            newFarmer.getUsers().stream().filter(user -> user.getUuid().equals(oldOwner)).findFirst().get().setPerm(FarmerPerm.MEMBER);
+            newFarmer.getUsers().stream().filter(user -> user.getUuid().equals(oldOwner)).findFirst().ifPresent(user -> user.setPerm(FarmerPerm.MEMBER));
             // Adds player if not exists on farmer users
             if (newFarmer.getUsers().stream().noneMatch(user -> user.getUuid().equals(newOwner)))
                 /*
@@ -87,7 +87,7 @@ public class FarmerManager {
                 // Replaces new owner role to owner on db
                 Main.getInstance().getSql().updateRole(newOwner, 2, newFarmer.getId());
                 // Replaces new owner role to owner on cache
-                newFarmer.getUsers().stream().filter(user -> user.getUuid().equals(newOwner)).findFirst().get().setPerm(FarmerPerm.OWNER);
+                newFarmer.getUsers().stream().filter(user -> user.getUuid().equals(newOwner)).findFirst().ifPresent(user -> user.setPerm(FarmerPerm.OWNER));
             }
             // Update farmer regionId if same as ownerid
             if (regionId.equals(oldOwner.toString()))

--- a/src/main/java/xyz/geik/farmer/integrations/townyadvanced/TownyListener.java
+++ b/src/main/java/xyz/geik/farmer/integrations/townyadvanced/TownyListener.java
@@ -4,9 +4,6 @@ import com.palmergames.bukkit.towny.event.DeleteTownEvent;
 import com.palmergames.bukkit.towny.event.NewTownEvent;
 import com.palmergames.bukkit.towny.event.TownAddResidentEvent;
 import com.palmergames.bukkit.towny.event.TownRemoveResidentEvent;
-import com.palmergames.bukkit.towny.event.player.PlayerEntersIntoTownBorderEvent;
-import com.palmergames.bukkit.towny.event.town.TownKickEvent;
-import com.palmergames.bukkit.towny.event.town.TownLeaveEvent;
 import com.palmergames.bukkit.towny.event.town.TownMayorChangeEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
@@ -77,7 +74,7 @@ public class TownyListener implements Listener {
         String townID = e.getTown().getUUID().toString();
         if (!FarmerManager.getFarmers().containsKey(townID))
             return;
-        UUID member = e.getResident().getPlayer().getUniqueId();
+        UUID member = e.getResident().getUUID();
         Farmer farmer = FarmerManager.getFarmers().get(townID);
         if (farmer.getUsers().stream().noneMatch(user -> user.getUuid().equals(member)))
             farmer.addUser(member, Bukkit.getOfflinePlayer(member).getName(), FarmerPerm.COOP);


### PR DESCRIPTION
Fixess NPE when handling offline player at `TownAddResidentEvent`. Fixes `NoSuchElementException` that occurs when attempting to modify roles for users not in the cache at `TownMayorChangeEvent`. Stacktrace:
```
[18:29:50] [Server thread/ERROR]: Could not pass event TownMayorChangeEvent to Farmer vv6-b108
java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.get(Optional.java:143) ~[?:?]
	at Farmer-v6-b108.jar/xyz.geik.farmer.api.managers.FarmerManager.changeOwner(FarmerManager.java:71) ~[Farmer-v6-b108.jar:?]
	at Farmer-v6-b108.jar/xyz.geik.farmer.integrations.townyadvanced.TownyListener.transferTown(TownyListener.java:68) ~[Farmer-v6-b108.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor1116.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:71) ~[leaf-1.21.1.jar:1.21.1-DEV-0927bfb]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[leaf-1.21.1.jar:1.21.1-DEV-0927bfb]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:629) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
	at Towny-0.100.4.0.jar/com.palmergames.bukkit.util.BukkitTools.fireEvent(BukkitTools.java:373) ~[Towny-0.100.4.0.jar:?]
	at Towny-0.100.4.0.jar/com.palmergames.bukkit.util.BukkitTools.isEventCancelled(BukkitTools.java:354) ~[Towny-0.100.4.0.jar:?]
	at Towny-0.100.4.0.jar/com.palmergames.bukkit.towny.command.TownCommand.lambda$townSetMayor$10(TownCommand.java:1998) ~[Towny-0.100.4.0.jar:?]
	at Towny-0.100.4.0.jar/com.palmergames.bukkit.towny.scheduling.TaskScheduler.lambda$run$1(TaskScheduler.java:82) ~[Towny-0.100.4.0.jar:?]
	at Towny-0.100.4.0.jar/com.palmergames.bukkit.towny.scheduling.impl.FoliaTaskScheduler.lambda$run$0(FoliaTaskScheduler.java:59) ~[Towny-0.100.4.0.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler$EntityScheduledTask.accept(FoliaEntityScheduler.java:168) ~[leaf-1.21.1.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler$EntityScheduledTask.accept(FoliaEntityScheduler.java:115) ~[leaf-1.21.1.jar:?]
	at io.papermc.paper.threadedregions.EntityScheduler.executeTick(EntityScheduler.java:185) ~[leaf-1.21.1.jar:1.21.1-DEV-0927bfb]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1767) ~[leaf-1.21.1.jar:1.21.1-DEV-0927bfb]
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:521) ~[leaf-1.21.1.jar:1.21.1-DEV-0927bfb]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1638) ~[leaf-1.21.1.jar:1.21.1-DEV-0927bfb]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1325) ~[leaf-1.21.1.jar:1.21.1-DEV-0927bfb]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:319) ~[leaf-1.21.1.jar:1.21.1-DEV-0927bfb]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```