### PR TITLE
Fix for latest Lands version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.github.angeschossen</groupId>
             <artifactId>LandsAPI</artifactId>
-            <version>7.1.12</version>
+            <version>7.10.6</version>
             <scope>provided</scope>
         </dependency>
         <!-- WildStacker -->

--- a/src/main/java/xyz/geik/farmer/commands/FarmerCommand.java
+++ b/src/main/java/xyz/geik/farmer/commands/FarmerCommand.java
@@ -98,8 +98,10 @@ public class FarmerCommand extends BaseCommand {
         }
         Player player = (Player) sender;
         String regionID = getRegionID(player);
-        if (regionID == null)
+        if (regionID == null) {
             ChatUtils.sendMessage(player, Main.getLangFile().getMessages().getNoRegion());
+            return;
+        }
 
         UUID ownerUUID = Main.getIntegration().getOwnerUUID(regionID);
         // Custom perm check for remove command

--- a/src/main/java/xyz/geik/farmer/integrations/lands/Lands.java
+++ b/src/main/java/xyz/geik/farmer/integrations/lands/Lands.java
@@ -38,7 +38,8 @@ public class Lands extends Integrations {
     @Override
     public UUID getOwnerUUID(String regionID) {
         ULID ulid = ULID.fromString(regionID);
-        return api.getLandByULID(ulid).getOwnerUID();
+        Land land = api.getLandByULID(ulid);
+        return land == null ? null : land.getOwnerUID();
     }
 
     /**


### PR DESCRIPTION
This PR fixes NullPointerException in the latest version of Lands. Wilderness area returns null on /farmer remove commands. This leads to this exception.