### PR TITLE
Add item-based permission check for farmer owner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>com.github.Geik-xyz</groupId>
             <artifactId>GLib</artifactId>
-            <version>ff5be79698</version>
+            <version>59d76256cf</version>
         </dependency>
         <!-- apache commons -->
         <dependency>

--- a/src/main/java/xyz/geik/farmer/configuration/ConfigFile.java
+++ b/src/main/java/xyz/geik/farmer/configuration/ConfigFile.java
@@ -119,6 +119,26 @@ public class ConfigFile extends OkaeriConfig {
         private String depositUser = "Geyik";
     }
 
+    @Comment("Permission settings")
+    private Permission permission = new Permission();
+
+    /**
+     * Permission configuration holder
+     */
+    @Getter
+    @Setter
+    public static class Permission extends OkaeriConfig{
+        @Comment({"Per permission for farmer items",
+                "You can use * character to allow all items",
+                "You can use item name to allow only that item",
+                "Example: farmer.item.WHEAT",
+        })
+        private String itemPermission = "farmer.item.";
+
+        @Comment("Activate if you want the Farmer to collect only certain items")
+        private boolean itemPermissionEnabled = false;
+    }
+
     /**
      * Gui's configuration holder
      */

--- a/src/main/java/xyz/geik/farmer/listeners/backend/ItemEvent.java
+++ b/src/main/java/xyz/geik/farmer/listeners/backend/ItemEvent.java
@@ -1,6 +1,7 @@
 package xyz.geik.farmer.listeners.backend;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;

--- a/src/main/java/xyz/geik/farmer/listeners/backend/ItemEvent.java
+++ b/src/main/java/xyz/geik/farmer/listeners/backend/ItemEvent.java
@@ -105,6 +105,13 @@ public class ItemEvent implements Listener {
         if (farmer.getState() == 0)
             return;
 
+        if(Main.getConfigFile().getPermission().isItemPermissionEnabled()){
+            String itemName = e.getEntity().getItemStack().getType().name().toUpperCase();
+            Player farmerOwner = Bukkit.getPlayer(farmer.getOwnerUUID());
+            if(!farmerOwner.hasPermission(Main.getConfigFile().getPermission().getItemPermission() + itemName) && !farmerOwner.hasPermission(Main.getConfigFile().getPermission().getItemPermission() + "*"))
+                return;
+        }
+
         // Calls FarmerItemCollectEvent
         FarmerItemCollectEvent collectEvent = new FarmerItemCollectEvent(farmer, item, item.getAmount(), e);
         Bukkit.getPluginManager().callEvent(collectEvent);


### PR DESCRIPTION
This pull request introduces changes to enhance permission-based item collection functionality for farmers in the plugin and updates a dependency version in the `pom.xml` file. The most important changes include adding a new `Permission` configuration class, implementing permission checks in the `itemSpawnEvent` method, and updating the `GLib` dependency version.

### Permission-based item collection functionality:

* [`src/main/java/xyz/geik/farmer/configuration/ConfigFile.java`](diffhunk://#diff-130e2a40cccb0220e8fe69f88e1cbcfa21ab8facf9be22097ae0dec4b00c5544R122-R141): Added a new `Permission` configuration class with fields for item-specific permissions (`itemPermission`) and a toggle (`itemPermissionEnabled`) to enable permission-based item collection. This allows farmers to collect items based on permissions.
* [`src/main/java/xyz/geik/farmer/listeners/backend/ItemEvent.java`](diffhunk://#diff-fbda696bf71fe76ad80ff5ef459f89a8aeb3f105ddbb4de98d84d1feab6c639aR109-R115): Updated the `itemSpawnEvent` method to include permission checks. Farmers will only collect items if the owner has the appropriate permissions for the item or a wildcard permission.

### Dependency update:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L100-R100): Updated the version of the `GLib` dependency from `ff5be79698` to `59d76256cf`, ensuring compatibility with the latest library features or fixes.

### Minor import addition:

* [`src/main/java/xyz/geik/farmer/listeners/backend/ItemEvent.java`](diffhunk://#diff-fbda696bf71fe76ad80ff5ef459f89a8aeb3f105ddbb4de98d84d1feab6c639aR4): Added an import for `org.bukkit.entity.Player` to support the new permission checks in the `itemSpawnEvent` method.