### PR TITLE
Added Folia support for ChatEvent using MorePaperLib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.geik.farmer</groupId>
     <artifactId>Farmer</artifactId>
-    <version>v6-b111</version>
+    <version>v6-b112</version>
 
     <properties>
         <shaded.package>org.cas.osd.platform.ciam.shaded</shaded.package>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.github.angeschossen</groupId>
             <artifactId>LandsAPI</artifactId>
-            <version>7.10.6</version>
+            <version>7.10.13</version>
             <scope>provided</scope>
         </dependency>
         <!-- WildStacker -->

--- a/src/main/java/xyz/geik/farmer/listeners/backend/ChatEvent.java
+++ b/src/main/java/xyz/geik/farmer/listeners/backend/ChatEvent.java
@@ -12,6 +12,7 @@ import xyz.geik.farmer.guis.UsersGui;
 import xyz.geik.farmer.model.Farmer;
 import xyz.geik.glib.chat.ChatUtils;
 import xyz.geik.glib.chat.Placeholder;
+import space.arim.morepaperlib.MorePaperLib;
 
 import java.util.Map;
 import java.util.UUID;
@@ -51,7 +52,8 @@ public class ChatEvent implements Listener {
             players.remove(playerName);
             return;
         }
-        Bukkit.getScheduler().runTask(Main.getInstance(), () -> {
+        MorePaperLib morePaperLib = new MorePaperLib(Main.getInstance());
+        morePaperLib.scheduling().entitySpecificScheduler(player).run(() -> {
             try {
                 Farmer farmer = FarmerManager.getFarmers().get(
                         Main.getIntegration().getRegionID(player.getLocation())
@@ -62,6 +64,7 @@ public class ChatEvent implements Listener {
                     players.remove(playerName);
                     return;
                 }
+
                 if (farmer.getUsers().stream().anyMatch(user -> user.getUuid().equals(targetUUID))) {
                     ChatUtils.sendMessage(player, Main.getLangFile().getMessages().getUserAlreadyExist(),
                             new Placeholder("{player}", input));
@@ -78,6 +81,6 @@ public class ChatEvent implements Listener {
                 players.remove(playerName);
                 ChatUtils.sendMessage(player, Main.getLangFile().getMessages().getUserCouldntFound());
             }
-        });
+        }, null);
     }
 }


### PR DESCRIPTION
Fixed the scheduler error on Folia during chat input. Used the existing MorePaperLib to make ChatEvent compatible with both Paper and Folia, resolving the UnsupportedOperationException.